### PR TITLE
misc: fix build errors in drivers/misc/starfive-otp.c

### DIFF
--- a/drivers/misc/starfive-otp.c
+++ b/drivers/misc/starfive-otp.c
@@ -114,8 +114,8 @@ struct starfive_otp_platdata {
 
 static void gpio_direction_output(u32 gpio, u32 val)
 {
-	volatile uint32_t __iomem *addr = EZGPIO_FULLMUX_BASE_ADDR + 0x50 +
-					  gpio * 8;
+	volatile uint32_t __iomem *addr = (void *)EZGPIO_FULLMUX_BASE_ADDR +
+					  0x50 + gpio * 8;
 
 	MA_OUTW(addr, val);
 	MA_OUTW(addr + 1, val);
@@ -123,8 +123,8 @@ static void gpio_direction_output(u32 gpio, u32 val)
 
 static void gpio_set_value(u32 gpio, u32 val)
 {
-	volatile uint32_t __iomem *addr = EZGPIO_FULLMUX_BASE_ADDR + 0x50 +
-					  gpio * 8;
+	volatile uint32_t __iomem *addr = (void *)EZGPIO_FULLMUX_BASE_ADDR +
+					  0x50 + gpio * 8;
 
 	MA_OUTW(addr, val);
 }
@@ -140,7 +140,7 @@ static int starfive_otp_read(struct udevice *dev, int offset,
 	int fuseidx = offset / BYTES_PER_FUSE;
 	int fusecount = size / BYTES_PER_FUSE;
 	u32 fusebuf[fusecount];
-	u32 addr = (u32)regs;
+	void *addr = regs;
 
 	/* Check if offset and size are multiple of BYTES_PER_FUSE */
 	if ((size % BYTES_PER_FUSE) || (offset % BYTES_PER_FUSE)) {


### PR DESCRIPTION
GCC 10 shows multiple build errors:

In file included from drivers/misc/starfive-otp.c:22:
drivers/misc/starfive-otp.c: In function ‘gpio_direction_output’:
./arch/riscv/include/asm/arch/global_reg.h:162:35: error:
initialization of ‘volatile uint32_t *’ {aka ‘volatile unsigned int *’}
from ‘long unsigned int’ makes pointer from integer without a cast
[-Werror=int-conversion]
  162 | #define EZGPIO_FULLMUX_BASE_ADDR  0x11910000UL
      |                                   ^~~~~~~~~~~~
drivers/misc/starfive-otp.c:143:13: error:
cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
  143 |  u32 addr = (u32)regs;
      |             ^

Correct the type of addr.
Convert EZGPIO_FULLMUX_BASE_ADDR to void *.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
