### PR TITLE
Remove fdt_high and initrd_high for Starfive JH7100

### DIFF
--- a/include/configs/starfive-vic7100.h
+++ b/include/configs/starfive-vic7100.h
@@ -108,8 +108,6 @@
 	"name=system,size=-,bootable,type=${type_guid_gpt_system};"
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"fdt_high=0xffffffffffffffff\0" \
-	"initrd_high=0xffffffffffffffff\0" \
 	"kernel_addr_r=0x84000000\0" \
 	"fdt_addr_r=0x88000000\0" \
 	"scriptaddr=0x88100000\0" \


### PR DESCRIPTION
Fix checkpatch warning about u-boot/include/configs/starfive-vic7100.h:
```
    ERROR: fdt or initrd relocation disabled at boot time
    +       "fdt_high=0xffffffffffffffff\0" \
    
    ERROR: fdt or initrd relocation disabled at boot time
    +       "initrd_high=0xffffffffffffffff\0" \
```
Further discussion of why this is not needed and the problem its presence was causing in issue #19

From the log of successful boot with this change:
```
U-Boot 2021.04 (Jun 07 2021 - 18:30:51 -0700)

CPU:   rv64imafdc
DRAM:  8 GiB
MMC:   sdio0@10000000: 0, sdio1@10010000: 1
Net:   dwmac.10020000
Error: dwmac.10020000 address ff:ff:ff:ff:ff:ff illegal value

Autoboot in 2 seconds
MMC CD is 0x1, force to True.
MMC CD is 0x1, force to True.
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found /boot/extlinux/extlinux.conf
Retrieving file: /boot/extlinux/extlinux.conf
183 bytes read in 9 ms (19.5 KiB/s)
1:      linux
Retrieving file: /boot/Image
19703296 bytes read in 2220 ms (8.5 MiB/s)
append: console=ttyS0,115200 earlyprintk root=PARTUUID=0fef845a-c6e1-45bc-82f7-002fa720f958 rootwait
Retrieving file: /boot/jh7100-beaglev-starlight.dtb
16262 bytes read in 10 ms (1.6 MiB/s)
Moving Image from 0x84000000 to 0x80200000, end=8151d000
## Flattened Device Tree blob at 88000000
   Booting using the fdt blob at 0x88000000
   Loading Device Tree to 00000000ffff8000, end 00000000ffffef85 ... OK

Starting kernel ...

Linux version 5.13.0-rc5-beaglev-starlight-00395-gad0a1f8705ca (pdp7@x1) (riscv64-linux-gnu-gcc (Ubuntu 10.2.0-8ubuntu1) 10.2.0, GNU ld (GNU Binutils for Ubuntu1
OF: fdt: Ignoring memory range 0x80000000 - 0x80200000
Machine model: BeagleV Starlight Beta
```
Full boot log is attached: 
[uboot-log.txt](https://github.com/starfive-tech/u-boot/files/6612971/uboot-log.txt)

NOTE: before upstream submission, all references to [VIC will be renamed to JH7100](https://github.com/beagleboard/beaglev-starlight#guidance-on-naming-conventions) which is the actual name of the StarFive SoC 