### PR TITLE
riscv: dts: starfive: Modify devicee tree for VisionFive to support W…

### DIFF
--- a/arch/riscv/dts/jh7100-visionfive.dts
+++ b/arch/riscv/dts/jh7100-visionfive.dts
@@ -20,7 +20,7 @@
 
 &gpio {
 	/* don't reset gpio mux for serial console and reset gpio */
-	starfive,keep-gpiomux = <13 14 63>;
+	starfive,keep-gpiomux = <13 14 63 0 2 3 45>;
 };
 
 &i2c0 {


### PR DESCRIPTION
riscv: dts: starfive: Modify devicee tree for VisionFive to support WM8960 daughter board

Modify the gpio node to keep i2s pins state.
    
 Signed-off-by: Som Qin <som.qin@starfivetech.com>
