### PR TITLE
exclude opensbi memory range in device tree

### DIFF
--- a/arch/riscv/dts/starfive_visionfive2.dts
+++ b/arch/riscv/dts/starfive_visionfive2.dts
@@ -34,6 +34,17 @@
 		reg = <0x0 0x40000000 0x1 0x0>;
 	};
 
+	reserved-memory {
+			#size-cells = <2>;
+			#address-cells = <2>;
+			ranges;
+
+			opensbi {
+				reg = <0x00 0x40000000 0x00 0x80000>;
+				no-map;
+			};
+	};
+
 	soc {
 	};
 };


### PR DESCRIPTION
This patch explicitly excludes the memory range of the OpenSBI in the built-in device tree. When booting EFI, the efi loader has to know about that zone before loading the device tree for Linux, otherwise it tries to access 0x40000000, leading to an access violation.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
