### PR TITLE
VisionFive 2: Add default device tree overlay address

### DIFF
--- a/include/configs/starfive-visionfive2.h
+++ b/include/configs/starfive-visionfive2.h
@@ -249,6 +249,7 @@
 	"script_size_f=0x1000\0"			\
 	"pxefile_addr_r=0x45900000\0"			\
 	"ramdisk_addr_r=0x46100000\0"			\
+	"fdtoverlay_addr_r=0x4f000000\0"		\
 	VF2_DISTRO_BOOTENV				\
 	VISIONFIVE2_BOOTENV				\
 	CHIPA_GMAC_SET					\


### PR DESCRIPTION
This is needed for device tree overlays to work when adding them via "fdtoverlays /path/to/overlay.dtbo" to extlinux.conf.

Of course this can be also set in uEnv.txt, but this U-Boot build reads that environment file from partition 3 with FAT filesystem only, which makes this an unnecessary limitation. Also, this variable is listed as "required" in upstream U-Boot docs: https://github.com/u-boot/u-boot/blob/master/doc/develop/distro.rst#required-environment-variables

To allow using device tree overlays on the VisionFive 2, including the one shipped with StarFive's own kernel build, via extlinux in a generic and upstream-compatible way, this variable is hereby added.

The used address is sufficiently distant from the initramfs address, also in case 0x48100000 is used (override via uEnv.txt in StarFive's Debian image).

Fixes #26 for the VisionFive 2