### PR TITLE
VisionFive 2: Add default compressed kernel address

### DIFF
--- a/include/configs/starfive-visionfive2.h
+++ b/include/configs/starfive-visionfive2.h
@@ -243,6 +243,8 @@
 	"fdt_high=0xffffffffffffffff\0"			\
 	"initrd_high=0xffffffffffffffff\0"		\
 	"kernel_addr_r=0x40200000\0"			\
+	"kernel_comp_addr_r=0x90000000\0"		\
+	"kernel_comp_size=0x10000000\0"			\
 	"fdt_addr_r=0x46000000\0"			\
 	"scriptaddr=0x43900000\0"			\
 	"script_offset_f=0x1fff000\0"			\


### PR DESCRIPTION
The default U-Boot environment does not provide kernel_comp_addr_r and kernel_comp_size, needed when using a compressed kernel image. Those are listed below "required" variables in upstream U-Boot to allow this feature without needed user configuration: https://github.com/u-boot/u-boot/blob/master/doc/develop/distro.rst#required-environment-variables

The values are taken from the uEnv.txt shipped by StarFive's own Debian images, which does use a gzip-compressed kernel image hence proven to be valid. Adding those values to the U-Boot default environment allows them to be removed from the dedicated uEnv.txt and enables support for compressed kernel images independent of the used uEnv.txt or whether one is used at all.
