### PR TITLE
Fix formatting of bootenv setting in config

### DIFF
--- a/include/configs/starfive-visionfive2.h
+++ b/include/configs/starfive-visionfive2.h
@@ -329,7 +329,7 @@
 		    "if test ${emmc_size} = 0; then "	\
 		        "setenv bootenv uEnv_Lite.txt;"    \
 		    "else "				   \
-		        "setenv bootenv uEnv_Lite_emmc.txt;" \	
+		        "setenv bootenv uEnv_Lite_emmc.txt;" \
 		     "fi; "				    \
 		"fi;" \
 		"run load_distro_uenv; " \


### PR DESCRIPTION
Fix the following warnings during compilation

include/configs/starfive-visionfive2.h:332:62: warning: backslash and newline separated by space
  332 |                         "setenv bootenv uEnv_Lite_emmc.txt;" \